### PR TITLE
Task 4: Semantic Kernel Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,15 @@ Execute the series of API requests below and analyze the responses to ensure the
     ]
   }
   ```
+
+ #
+ # Plugins
+
+ ## StorePersonalDataPlugin
+ Plugin to store personal data gathered from user during conversation in the chat history.
+ Classify data type and store it as map [<data type>, <data>]
+
+ ## LightsPlugin
+ Plugin to control lights in the room. You can tun on, turn off, in specific spot or all.
+ And can get list with all available lights and their states.
+

--- a/src/main/java/com/epam/training/gen/ai/config/AiConfig.java
+++ b/src/main/java/com/epam/training/gen/ai/config/AiConfig.java
@@ -9,9 +9,13 @@ import org.springframework.web.client.RestTemplate;
 import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
+import com.epam.training.gen.ai.plugin.LightsPlugin;
+import com.epam.training.gen.ai.plugin.SimplePlugin;
+import com.epam.training.gen.ai.plugin.StorePersonalDataPlugin;
 import com.microsoft.semantickernel.Kernel;
 import com.microsoft.semantickernel.aiservices.openai.chatcompletion.OpenAIChatCompletion;
 import com.microsoft.semantickernel.plugin.KernelPlugin;
+import com.microsoft.semantickernel.plugin.KernelPluginFactory;
 import com.microsoft.semantickernel.services.chatcompletion.ChatCompletionService;
 import com.microsoft.semantickernel.services.chatcompletion.ChatHistory;
 
@@ -42,11 +46,32 @@ public class AiConfig {
   }
 
   @Bean
+  public KernelPlugin kernelSimplePlugin() {
+    return KernelPluginFactory.createFromObject(new SimplePlugin(), "SimplePlugin");
+  }
+
+  @Bean
+  public KernelPlugin kernelLightsPlugin() {
+    return KernelPluginFactory.createFromObject(new LightsPlugin(), "LightsPlugin");
+  }
+
+  @Bean
+  public KernelPlugin kernelStorePersonalDataPlugin() {
+    return KernelPluginFactory.createFromObject(new StorePersonalDataPlugin(), "StorePersonalDataPlugin");
+  }
+
+  @Bean
   public Kernel kernel(
-    final ChatCompletionService chatCompletionService
+    final ChatCompletionService chatCompletionService,
+    final KernelPlugin kernelSimplePlugin,
+    final KernelPlugin kernelLightsPlugin,
+    final KernelPlugin kernelStorePersonalDataPlugin
   ) {
     return Kernel.builder()
       .withAIService(ChatCompletionService.class, chatCompletionService)
+      .withPlugin(kernelSimplePlugin)
+      .withPlugin(kernelLightsPlugin)
+      .withPlugin(kernelStorePersonalDataPlugin)
       .build();
   }
 

--- a/src/main/java/com/epam/training/gen/ai/model/LightModel.java
+++ b/src/main/java/com/epam/training/gen/ai/model/LightModel.java
@@ -1,0 +1,19 @@
+package com.epam.training.gen.ai.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+import lombok.ToString;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@Setter
+@ToString
+public class LightModel {
+  private int id;
+  private String name;
+  private boolean isOn;
+
+}

--- a/src/main/java/com/epam/training/gen/ai/model/UserRecord.java
+++ b/src/main/java/com/epam/training/gen/ai/model/UserRecord.java
@@ -1,0 +1,16 @@
+package com.epam.training.gen.ai.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@Setter
+public class UserRecord {
+  private String recordType;
+  private String content;
+
+}

--- a/src/main/java/com/epam/training/gen/ai/plugin/LightsPlugin.java
+++ b/src/main/java/com/epam/training/gen/ai/plugin/LightsPlugin.java
@@ -1,0 +1,48 @@
+package com.epam.training.gen.ai.plugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.epam.training.gen.ai.model.LightModel;
+import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class LightsPlugin {
+
+  // Mock data for the lights
+  private final Map<Integer, LightModel> lights = new HashMap<>();
+
+  public LightsPlugin() {
+    log.info("Plugin run! Lights plugin initialized");
+    lights.put(1, new LightModel(1, "Table Lamp", false));
+    lights.put(2, new LightModel(2, "Porch light", false));
+    lights.put(3, new LightModel(3, "Chandelier", true));
+  }
+
+  @DefineKernelFunction(name = "get_lights", description = "Gets a list of lights and their current state")
+  public List<LightModel> getLights() {
+    log.info("Plugin run! Getting lights");
+    return new ArrayList<>(lights.values());
+  }
+
+  @DefineKernelFunction(name = "change_state", description = "Changes the state of the light")
+  public LightModel changeState(
+    @KernelFunctionParameter(name = "id", description = "The ID of the light to change") final int id,
+    @KernelFunctionParameter(name = "isOn", description = "The new state of the light") final boolean isOn
+  ) {
+
+    log.info("Plugin run! Changing light {}: {}", id, isOn);
+    if (!lights.containsKey(id)) {
+      throw new IllegalArgumentException("Light not found");
+    }
+
+    lights.get(id).setOn(isOn);
+
+    return lights.get(id);
+  }
+}

--- a/src/main/java/com/epam/training/gen/ai/plugin/SimplePlugin.java
+++ b/src/main/java/com/epam/training/gen/ai/plugin/SimplePlugin.java
@@ -1,0 +1,17 @@
+package com.epam.training.gen.ai.plugin;
+
+import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class SimplePlugin {
+
+  @DefineKernelFunction(name = "make_simple_action", description = "Makes a simple action on data.")
+  public String getBingSearchUrl(
+    @KernelFunctionParameter(description = "Data on which to do action", name = "query") String query) {
+    log.info("Simple plugin was called with query: [{}]", query);
+    return query;
+  }
+}

--- a/src/main/java/com/epam/training/gen/ai/plugin/StorePersonalDataPlugin.java
+++ b/src/main/java/com/epam/training/gen/ai/plugin/StorePersonalDataPlugin.java
@@ -1,0 +1,44 @@
+package com.epam.training.gen.ai.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.epam.training.gen.ai.model.UserRecord;
+import com.microsoft.semantickernel.semanticfunctions.annotations.DefineKernelFunction;
+import com.microsoft.semantickernel.semanticfunctions.annotations.KernelFunctionParameter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class StorePersonalDataPlugin {
+
+  // instead of repository
+  private final List<UserRecord> userRecords = new ArrayList<>();
+
+  public StorePersonalDataPlugin() {
+    log.info("Plugin run! StorePersonalDataPlugin initialized");
+  }
+
+  @DefineKernelFunction(
+    name = "get_user_data",
+    description = "Gets all collected user personal data, preserved during conversation"
+  )
+  public List<UserRecord> getUserData() {
+    log.info("Plugin run! Getting all user data");
+    return userRecords;
+  }
+
+  @DefineKernelFunction(name = "add_data", description = "Adds user data gathered during conversation")
+  public UserRecord addData(
+    @KernelFunctionParameter(name = "recordType", description = "Type of user data") final String recordType,
+    @KernelFunctionParameter(name = "content", description = "The user data by itself") final String content
+  ) {
+
+    log.info("Plugin run! Saving used data {}: {} ", recordType, content);
+
+    final UserRecord userRecord = new UserRecord(recordType, content);
+    userRecords.add(userRecord);
+
+    return userRecord;
+  }
+}


### PR DESCRIPTION
### **Module 4**
- Two plugins added
- First controls lights and gives lists
- Second, collects all user personal data in conversation and store it

### Work verification 

- [ ] **Step 1.** Asked about lights and received the initial list
```
Table Lamp, off
Porch light, off
Chandelier, on
```
![Uploading Screenshot 2024-12-13 at 20.47.56.png…]()

- [ ] **Step 2.** Asked to turn all on
![Screenshot 2024-12-13 at 20 48 50](https://github.com/user-attachments/assets/824fed76-58a1-4fae-9284-b48dd3802019)

- [ ] **Step 3.** Give to chat some info about me
![Screenshot 2024-12-13 at 20 49 42](https://github.com/user-attachments/assets/5a5b99b2-2a45-4b2f-bbe4-a1948f9098e2)

- [ ] **Step 4.** I asked  to turn off all lights except the table lamp, then give me the list of all lights with their states, and all my personal data
![Screenshot 2024-12-13 at 21 07 08](https://github.com/user-attachments/assets/7c59197c-d5e7-439f-bc1e-af2ed5184d8b)

**As we can see all light was turned off except Table one, and chat was preserving my personal info in a categorized way. That shows that both plugins work well** 

### Response from logs:
<img width="783" alt="Screenshot 2024-12-13 at 21 09 08" src="https://github.com/user-attachments/assets/9a8f9339-a45e-42f4-b2bd-f74c261871f0" />
